### PR TITLE
fix(api): reuse existing FirebaseAuthGuard provider

### DIFF
--- a/apps/api/src/app.module.spec.ts
+++ b/apps/api/src/app.module.spec.ts
@@ -1,0 +1,10 @@
+import { Test } from '@nestjs/testing';
+import { AppModule } from './app.module';
+
+describe('AppModule', () => {
+  it('May be created without throwing', async () => {
+    await expect(
+      Test.createTestingModule({ imports: [AppModule] }).compile(),
+    ).resolves.not.toThrow();
+  });
+});

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -16,6 +16,6 @@ import { TodosModule } from './todos/todos.module';
     SharedHttpModule,
   ],
   controllers: [],
-  providers: [{ provide: APP_GUARD, useClass: FirebaseAuthGuard }],
+  providers: [{ provide: APP_GUARD, useExisting: FirebaseAuthGuard }],
 })
 export class AppModule {}

--- a/apps/mcp/src/app.module.spec.ts
+++ b/apps/mcp/src/app.module.spec.ts
@@ -1,0 +1,10 @@
+import { Test } from '@nestjs/testing';
+import { AppModule } from './app.module';
+
+describe('AppModule', () => {
+  it('May be created without throwing', async () => {
+    await expect(
+      Test.createTestingModule({ imports: [AppModule] }).compile(),
+    ).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- reuse the existing `FirebaseAuthGuard` provider for the API global `APP_GUARD` binding
- add AppModule compilation regression tests for API and MCP
- prevent startup/module wiring regressions from slipping through

## Validation
- `yarn biome check apps/api/src/app.module.ts apps/api/src/app.module.spec.ts apps/mcp/src/app.module.spec.ts`
- targeted Vitest passed for API and MCP AppModule specs

Fixes #77